### PR TITLE
suggest --socks5-hostname for testing from host step

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The container simply has an OpenVPN installation and a network interface `tun0` 
 
 Test if it work on your **host**
 
-	curl --socks5 localhost:9050 http://ipinfo.io/
+	curl --socks5-hostname localhost:9050 http://ipinfo.io/
 
 If you can't find `danted` process in the `ps -ef` inside container
 


### PR DESCRIPTION
As this will also route the DNS queries through dante thus through openvpn. This would help catch issues to with DNS resolving problems because of openvpn config as per the [issue I had](https://gist.github.com/zpoint/df2483c6beb97816e34ddbde3f62f5d8?permalink_comment_id=4533076#gistcomment-4533076)